### PR TITLE
1回目のいいね通知をやめる

### DIFF
--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -67,11 +67,7 @@ module.exports = robot => {
                 displayName = user.name;
               }
 
-              if (
-                newGoodcount === 1 ||
-                newGoodcount === 5 ||
-                newGoodcount % 10 === 0
-              ) {
+              if (newGoodcount === 5 || newGoodcount % 10 === 0) {
                 res.send(
                   `${displayName}ちゃん、すごーい！記念すべき ${newGoodcount} 回目のいいねだよ！おめでとー！`
                 );
@@ -106,9 +102,7 @@ module.exports = robot => {
         goodcount: 0
       }
     }).spread((goodcount, isCreated) => {
-      const message = `${username}ちゃんのいいねは ${
-        goodcount.goodcount
-      } こだよ！`;
+      const message = `${username}ちゃんのいいねは ${goodcount.goodcount} こだよ！`;
       msg.send(message);
     });
   });


### PR DESCRIPTION
通学コースのオフライン授業にて、普段Slackで発言しない生徒が多く発言し、サーバルちゃんの「すごーい！記念すべき 1 回目のいいねだよ！おめでとー！」が高い頻度で現れてしまいました。

それを受けて、初回は通知がなくてもよいのではないでしょうか、という提案です。